### PR TITLE
Apply dark to light blue ombre color scheme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,7 @@ body {
 .header {
     margin-bottom: 30px;
     padding: 30px 0;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #0a1f44 0%, #2563eb 50%, #93c5fd 100%);
     color: white;
     border-radius: 12px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -137,7 +137,7 @@ body {
 
 .progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #667eea, #764ba2);
+    background: linear-gradient(90deg, #0a1f44, #2563eb, #93c5fd);
     border-radius: 4px;
     transition: width 0.3s ease;
     width: 20%;
@@ -261,7 +261,7 @@ body {
 
 /* Buttons */
 .btn-primary {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #0a1f44 0%, #2563eb 50%, #93c5fd 100%);
     color: white;
     border: none;
     padding: 12px 24px;
@@ -746,7 +746,7 @@ body {
 
 .completion-fill {
     height: 100%;
-    background: linear-gradient(90deg, #10b981, #059669);
+    background: linear-gradient(90deg, #0a1f44, #2563eb, #93c5fd);
     border-radius: 4px;
     transition: width 0.3s ease;
 }
@@ -1090,7 +1090,7 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #0a1f44 0%, #2563eb 50%, #93c5fd 100%);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1139,7 +1139,7 @@ body {
 }
 
 .completion-actions .btn-primary {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #0a1f44 0%, #2563eb 50%, #93c5fd 100%);
     color: white;
 }
 


### PR DESCRIPTION
Update gradients in `styles.css` to a dark blue to light blue ombre.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6623748-3cc4-4da9-8df8-79083d79992d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6623748-3cc4-4da9-8df8-79083d79992d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

