### PR TITLE
Fallback to print dialog for pdf

### DIFF
--- a/api.php
+++ b/api.php
@@ -1,5 +1,6 @@
 <?php
-header('Content-Type: application/json');
+// Note: Do not set a global Content-Type header here because this file
+// returns both JSON and binary (PDF) responses depending on the endpoint.
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
 header('Access-Control-Allow-Headers: Content-Type, Authorization');
@@ -19,12 +20,14 @@ $password = '';
 // Error handling function
 function sendError($message, $code = 400) {
     http_response_code($code);
+    header('Content-Type: application/json');
     echo json_encode(['error' => $message]);
     exit();
 }
 
 // Success response function
 function sendSuccess($data = null, $message = 'Success') {
+    header('Content-Type: application/json');
     echo json_encode([
         'success' => true,
         'message' => $message,


### PR DESCRIPTION
Fix server PDF generation by setting JSON headers conditionally and improve client-side PDF fallback with jsPDF.

The server was sending JSON headers with PDF files, corrupting them. This PR moves the JSON header setting in `api.php` to only apply to actual JSON responses. Additionally, the client-side `downloadPDF` function's error handling is enhanced to first attempt a client-side PDF generation using `jsPDF` before falling back to the browser's print dialog, offering a more resilient PDF export experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-640214d0-ac35-4175-85f5-2b77bb076290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-640214d0-ac35-4175-85f5-2b77bb076290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

